### PR TITLE
Match particle colours to profile photo electric blue

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       width: 100%;
       height: 100%;
       overflow: hidden;
-      background: #020b18;
+      background: #00000f;
       font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', system-ui, sans-serif;
     }
 
@@ -131,11 +131,11 @@
     const dpr = Math.min(window.devicePixelRatio, 2);
     renderer.setPixelRatio(dpr);
     renderer.setSize(window.innerWidth, window.innerHeight);
-    renderer.setClearColor(0x020b18, 1);
+    renderer.setClearColor(0x00000f, 1);
 
     // ── Scene & Camera ────────────────────────────────────────────────────
     const scene = new THREE.Scene();
-    scene.fog = new THREE.FogExp2(0x020b18, 0.026);
+    scene.fog = new THREE.FogExp2(0x00000f, 0.026);
 
     const camera = new THREE.PerspectiveCamera(55, window.innerWidth / window.innerHeight, 0.1, 1000);
     camera.position.set(0, 11, 28);
@@ -245,11 +245,11 @@
         // Map elevation to [0,1]
         float t = clamp(vElevation * 0.32 + 0.48, 0.0, 1.0);
 
-        // Ocean colour ramp: deep navy → mid blue → cyan → near-white foam
-        vec3 deep  = vec3(0.00, 0.04, 0.20);
-        vec3 mid   = vec3(0.00, 0.22, 0.55);
-        vec3 surf  = vec3(0.00, 0.62, 0.88);
-        vec3 foam  = vec3(0.78, 0.96, 1.00);
+        // Colour ramp matched to profile photo electric blue background
+        vec3 deep  = vec3(0.00, 0.01, 0.10);  // near black-blue
+        vec3 mid   = vec3(0.02, 0.05, 0.48);  // deep electric blue
+        vec3 surf  = vec3(0.07, 0.16, 0.95);  // vivid royal blue (~#1228f2)
+        vec3 foam  = vec3(0.35, 0.48, 1.00);  // bright periwinkle highlight
 
         vec3 col;
         if      (t < 0.42) col = mix(deep, mid,  t / 0.42);
@@ -320,7 +320,7 @@
           float d = length(gl_PointCoord - 0.5);
           if (d > 0.5) discard;
           float a = smoothstep(0.5, 0.0, d) * vAlpha;
-          gl_FragColor = vec4(0.7, 0.88, 1.0, a);
+          gl_FragColor = vec4(0.40, 0.52, 1.0, a);
         }
       `,
       transparent: true,


### PR DESCRIPTION
## Summary

- Updates the particle ocean colour ramp to match the vivid electric blue of the profile photo background
- Ramp: near-black → deep electric blue → vivid royal blue (`~#1228f2`) → bright periwinkle at wave peaks
- Star tint and background/fog colour aligned to the same palette

## Test plan

- [ ] Particles display in electric/royal blue tones matching the profile photo
- [ ] Wave peaks show bright periwinkle highlights
- [ ] Background feels cohesive with the profile photo

https://claude.ai/code/session_01SmxDFqNnGd8t5KP6SPpQGE