### PR TITLE
Add cinematic Three.js camera intro synced with profile fade-in

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,11 +48,13 @@
       width: clamp(180px, 32vw, 280px);
       height: auto;
       opacity: 0;
-      transform: scale(0.85);
+      transform: scale(0.88);
+      transition: opacity 1.6s ease, transform 1.6s ease;
     }
 
-    .profile-photo.animate {
-      animation: photoEntrance 1s ease-out forwards;
+    .profile-photo.revealed {
+      opacity: 1;
+      transform: scale(1);
     }
 
     .info {
@@ -67,11 +69,13 @@
       margin-bottom: 8px;
       white-space: nowrap;
       opacity: 0;
-      transform: translateY(15px);
+      transform: translateY(14px);
+      transition: opacity 1.1s ease, transform 1.1s ease;
     }
 
-    .name.animate {
-      animation: textEntrance 0.8s ease-out forwards;
+    .name.revealed {
+      opacity: 1;
+      transform: translateY(0);
     }
 
     .role {
@@ -80,26 +84,13 @@
       letter-spacing: 0.04em;
       white-space: nowrap;
       opacity: 0;
-      transform: translateY(15px);
+      transform: translateY(14px);
+      transition: opacity 1.1s ease, transform 1.1s ease;
     }
 
-    .role.animate {
-      animation: roleEntrance 0.8s ease-out forwards;
-    }
-
-    @keyframes photoEntrance {
-      0%   { opacity: 0; transform: scale(0.85); }
-      100% { opacity: 1; transform: scale(1); }
-    }
-
-    @keyframes textEntrance {
-      0%   { opacity: 0; transform: translateY(15px); }
-      100% { opacity: 1; transform: translateY(0); }
-    }
-
-    @keyframes roleEntrance {
-      0%   { opacity: 0; transform: translateY(15px); }
-      100% { opacity: 0.5; transform: translateY(0); }
+    .role.revealed {
+      opacity: 0.5;
+      transform: translateY(0);
     }
   </style>
 </head>
@@ -135,11 +126,28 @@
 
     // ── Scene & Camera ────────────────────────────────────────────────────
     const scene = new THREE.Scene();
-    scene.fog = new THREE.FogExp2(0x00000f, 0.026);
+    scene.fog = new THREE.FogExp2(0x00000f, 0.09); // dense at start, clears during intro
 
     const camera = new THREE.PerspectiveCamera(55, window.innerWidth / window.innerHeight, 0.1, 1000);
-    camera.position.set(0, 11, 28);
-    camera.lookAt(0, -3, 0);
+
+    // ── Intro camera path ─────────────────────────────────────────────────
+    // Sweeps from close to the wave surface up to the settled overview position
+    const INTRO_DUR   = 3.4;
+    const camFrom     = new THREE.Vector3(14, 0.6, 4);
+    const camTo       = new THREE.Vector3(0, 11, 28);
+    const atFrom      = new THREE.Vector3(0, 2.5, -6);
+    const atTo        = new THREE.Vector3(0, -3, 0);
+    const lookTarget  = new THREE.Vector3();
+
+    function easeInOutCubic(t) {
+      return t < 0.5 ? 4*t*t*t : 1 - Math.pow(-2*t + 2, 3) / 2;
+    }
+
+    // DOM elements revealed in sync with camera arrival
+    const photoEl = document.querySelector('.profile-photo');
+    const nameEl  = document.querySelector('.name');
+    const roleEl  = document.querySelector('.role');
+    let photoShown = false, nameShown = false, roleShown = false;
 
     // ── Mouse / Touch ─────────────────────────────────────────────────────
     const mouse       = new THREE.Vector2(0, 0);
@@ -190,7 +198,6 @@
       varying float vElevation;
       varying float vEdgeFade;
 
-      // Gerstner wave — returns XYZ displacement
       vec3 gerstner(vec2 pos, vec2 dir, float steepness, float wl, float spd) {
         float k = 6.28318 / wl;
         float c = sqrt(9.81 / k) * spd;
@@ -202,7 +209,6 @@
       void main() {
         vec3 pos = position;
 
-        // Six layered waves — vary direction, steepness, wavelength & speed
         vec3 w  = gerstner(pos.xz, vec2( 1.00,  0.30), 0.55, 12.0, 0.40);
             w += gerstner(pos.xz, vec2(-0.60,  1.00), 0.45,  8.0, 0.55);
             w += gerstner(pos.xz, vec2( 0.40, -0.80), 0.35,  5.5, 0.70);
@@ -212,21 +218,18 @@
 
         pos += w;
 
-        // Mouse-driven ripple
         vec2  mWorld = uMouse * 18.0;
         float mDist  = distance(pos.xz, mWorld);
         pos.y += sin(mDist * 1.3 - uTime * 4.5) * exp(-mDist * 0.20) * 2.2;
 
         vElevation = pos.y;
 
-        // Fade particles near grid boundary
         float edge = length(position.xz) / (${SPREAD.toFixed(1)} * 0.5);
         vEdgeFade  = 1.0 - smoothstep(0.52, 1.0, edge);
 
         vec4 mvPos   = modelViewMatrix * vec4(pos, 1.0);
         gl_Position  = projectionMatrix * mvPos;
 
-        // Point size: bigger at wave peaks & for random "sparkle" particles
         float sz = (1.8 + aRandom * 2.8 + max(0.0, vElevation) * 0.9) * uPixelRatio;
         gl_PointSize = clamp(sz * 20.0 / -mvPos.z, 1.0, 16.0);
       }
@@ -242,24 +245,21 @@
         float d  = length(uv);
         if (d > 0.5) discard;
 
-        // Map elevation to [0,1]
         float t = clamp(vElevation * 0.32 + 0.48, 0.0, 1.0);
 
-        // Colour ramp matched to profile photo electric blue background
-        vec3 deep  = vec3(0.00, 0.01, 0.10);  // near black-blue
-        vec3 mid   = vec3(0.02, 0.05, 0.48);  // deep electric blue
-        vec3 surf  = vec3(0.07, 0.16, 0.95);  // vivid royal blue (~#1228f2)
-        vec3 foam  = vec3(0.35, 0.48, 1.00);  // bright periwinkle highlight
+        vec3 deep  = vec3(0.00, 0.01, 0.10);
+        vec3 mid   = vec3(0.02, 0.05, 0.48);
+        vec3 surf  = vec3(0.07, 0.16, 0.95);
+        vec3 foam  = vec3(0.35, 0.48, 1.00);
 
         vec3 col;
         if      (t < 0.42) col = mix(deep, mid,  t / 0.42);
         else if (t < 0.78) col = mix(mid,  surf, (t - 0.42) / 0.36);
         else               col = mix(surf, foam, (t - 0.78) / 0.22);
 
-        // Soft circular disc with edge fade
         float alpha = pow((0.5 - d) / 0.5, 1.5);
         alpha *= vEdgeFade;
-        alpha *= 0.82 + t * 0.18;   // peaks slightly brighter
+        alpha *= 0.82 + t * 0.18;
 
         gl_FragColor = vec4(col, alpha);
       }
@@ -336,24 +336,50 @@
 
     function animate() {
       requestAnimationFrame(animate);
-      const t = clock.getElapsedTime();
+      const elapsed = clock.getElapsedTime();
 
       // Smooth mouse lag
       mouse.x += (targetMouse.x - mouse.x) * 0.04;
       mouse.y += (targetMouse.y - mouse.y) * 0.04;
 
-      mat.uniforms.uTime.value       = t;
+      mat.uniforms.uTime.value     = elapsed;
       mat.uniforms.uMouse.value.copy(mouse);
-      starMat.uniforms.uTime.value   = t;
+      starMat.uniforms.uTime.value = elapsed;
 
-      // Parallax camera drift
-      camera.position.x = mouse.x * 3.5;
-      camera.position.y = 11 + mouse.y * 2;
-      camera.lookAt(0, -3 + mouse.y * 0.6, 0);
+      // ── Cinematic intro ─────────────────────────────────────────────────
+      const raw   = Math.min(elapsed / INTRO_DUR, 1.0);
+      const eased = easeInOutCubic(raw);
 
-      // Stars drift slowly
+      // Camera position & lookAt sweep
+      camera.position.lerpVectors(camFrom, camTo, eased);
+      lookTarget.lerpVectors(atFrom, atTo, eased);
+
+      // Mouse parallax fades in smoothly after intro settles (over 1s)
+      const mouseBlend = Math.min(Math.max(elapsed - INTRO_DUR, 0) / 1.0, 1.0);
+      camera.position.x += mouse.x * 3.5 * mouseBlend;
+      camera.position.y += mouse.y * 2.0 * mouseBlend;
+      lookTarget.y      += mouse.y * 0.6 * mouseBlend;
+
+      camera.lookAt(lookTarget);
+
+      // Fog clears as camera rises from the surface
+      scene.fog.density = 0.09 - eased * (0.09 - 0.026);
+
+      // ── Sync DOM reveals with camera progress ───────────────────────────
+      if (!photoShown && raw > 0.58) {
+        photoEl.classList.add('revealed');
+        photoShown = true;
+      }
+      if (!nameShown && raw > 0.74) {
+        nameEl.classList.add('revealed');
+        nameShown = true;
+      }
+      if (!roleShown && raw > 0.86) {
+        roleEl.classList.add('revealed');
+        roleShown = true;
+      }
+
       stars.rotation.y += 0.00008;
-
       renderer.render(scene, camera);
     }
 
@@ -368,16 +394,6 @@
       const d = Math.min(window.devicePixelRatio, 2);
       mat.uniforms.uPixelRatio.value = d;
       starMat.uniforms.uDPR.value    = d;
-    });
-
-    // ── Entrance animations ───────────────────────────────────────────────
-    const show = (id, delay) =>
-      setTimeout(() => document.getElementById(id)?.classList.add('visible'), delay);
-
-    window.addEventListener('load', () => {
-      setTimeout(() => document.querySelector('.profile-photo').classList.add('animate'), 300);
-      setTimeout(() => document.querySelector('.name').classList.add('animate'), 800);
-      setTimeout(() => document.querySelector('.role').classList.add('animate'), 1000);
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary

- Camera sweeps from close to the wave surface (low, off-centre) up to the settled overview over 3.4s with `easeInOutCubic`
- Fog density animates from dense → clear as the camera rises, so the scene emerges from a blue haze
- Profile photo, name, and role are revealed via CSS transitions triggered at 58%, 74%, and 86% of intro progress
- Mouse parallax blends in over 1s after the intro completes

## Test plan

- [ ] On load, camera starts close to the wave surface and sweeps up
- [ ] Fog clears as the camera rises
- [ ] Profile photo fades + scales in mid-sweep, name and role follow
- [ ] After intro, mouse parallax works smoothly with no jarring cut
- [ ] Works on mobile

https://claude.ai/code/session_01SmxDFqNnGd8t5KP6SPpQGE